### PR TITLE
Fix testing Markdown files with Windows line endings

### DIFF
--- a/src/extract_gfm_code_blocks.js
+++ b/src/extract_gfm_code_blocks.js
@@ -1,5 +1,6 @@
 import Markdown from 'markdown-it'
 import regex from 'regex-fun'
+import split_lines_keep_line_endings from './split_lines_keep_line_endings.js'
 const lineBreak = regex.either(/\r\n/, /\r/, /\n/)
 
 const make_html_comment_code_block_regex = languages => regex.combine(
@@ -29,11 +30,10 @@ const tokenTypeHandlers = {
 }
 
 export const extract_gfm_code_blocks = (gfm, { languages }) => {
-	const lineIndexes = gfm
-		.split(lineBreak)
+	const lineIndexes = split_lines_keep_line_endings(gfm)
 		.reduce(
 			(acc, line, index) => {
-				const start = index === 0 ? 0 : acc[index - 1].end + 1
+				const start = index === 0 ? 0 : acc[index - 1].end
 				const end = start + line.length
 				acc.push({ start, end })
 				return acc

--- a/src/js_from_gfm.js
+++ b/src/js_from_gfm.js
@@ -1,13 +1,12 @@
 import MagicString from 'magic-string'
 import regex from 'regex-fun'
 import { extract_gfm_code_blocks } from './extract_gfm_code_blocks.js'
-const lineBreak = regex.either(/\r\n/, /\r/, /\n/)
 
 export const js_from_gfm = (gfm, { file = 'source.md' } = {}) => {
 	const blocks = extract_gfm_code_blocks(gfm, { languages: [ 'js', 'javascript' ] })
 	const { s, nextIndex } = blocks
 		.reduce(
-			({ s, nextIndex }, block) => ({ s: s.remove(nextIndex, block.startIndex - 1), nextIndex: block.endIndex + 1 }),
+			({ s, nextIndex }, block) => ({ s: s.remove(nextIndex, block.startIndex), nextIndex: block.endIndex }),
 			{ s: new MagicString(gfm), nextIndex: 0 }
 		)
 	nextIndex < gfm.length && s.remove(nextIndex, gfm.length)

--- a/src/split_lines_keep_line_endings.js
+++ b/src/split_lines_keep_line_endings.js
@@ -1,0 +1,13 @@
+import regex from 'regex-fun'
+const lineBreak = regex.either(/\r\n/, /\r/, /\n/)
+
+export default string => string
+	.split(regex.capture(lineBreak))
+	.reduce((acc, line_or_eol, i) => {
+		if (i % 2 === 0) {
+			acc.push(line_or_eol)
+		} else {
+			acc.push(acc.pop() + line_or_eol)
+		}
+		return acc
+	}, [])

--- a/test/arrow-explicit-return/arrow-explicit-return.spec.js
+++ b/test/arrow-explicit-return/arrow-explicit-return.spec.js
@@ -1,7 +1,8 @@
 import { test } from 'zora'
 import path from 'path'
+import { fileURLToPath } from 'url'
 import { verify_file } from '../../src/verify_file.js'
-const __dirname = path.dirname(new URL(import.meta.url).pathname)
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 test('arrow-explicit-return', async t => {
 	const { code, failed, output } = await verify_file(path.join(__dirname, './arrow-explicit-return.md'))

--- a/test/arrow-implied-return/arrow-implied-return.spec.js
+++ b/test/arrow-implied-return/arrow-implied-return.spec.js
@@ -1,7 +1,8 @@
 import { test } from 'zora'
 import path from 'path'
+import { fileURLToPath } from 'url'
 import { verify_file } from '../../src/verify_file.js'
-const __dirname = path.dirname(new URL(import.meta.url).pathname)
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 test('arrow-implied-return', async t => {
 	const { code, failed, output } = await verify_file(path.join(__dirname, './arrow-implied-return.md'))

--- a/test/split-lines-keep-line-endings/split-lines-keep-line-endings.js
+++ b/test/split-lines-keep-line-endings/split-lines-keep-line-endings.js
@@ -1,0 +1,14 @@
+import { test } from 'zora'
+import split_lines_keep_line_endings from '../../src/split_lines_keep_line_endings.js'
+
+test('split_lines_keep_line_endings', t => {
+	t.equal(
+		split_lines_keep_line_endings('\n\t\tthis is a test\n\t\tanother line\n')
+		[ '\n', '\t\tthis is a test', '\t\tanother line\n' ]
+	)
+
+	t.equal(
+		split_lines_keep_line_endings('test\r\n123')
+		[ 'test\r\n', '123' ]
+	)
+})

--- a/test/windows-line-endings/windows-line-endings.spec.js
+++ b/test/windows-line-endings/windows-line-endings.spec.js
@@ -1,0 +1,17 @@
+import { test } from 'zora'
+import { verify } from '../../src/verify.js'
+
+// Git will sometimes mess with line endings, thus the inline declaration
+const contents_unix_eol = '```js\nconst x = 1234\nx // => 1234\n```\n'
+
+test('unix line endings', async t => {
+	const { code, failed, output } = await verify(contents_unix_eol)
+	t.notOk(failed)
+})
+
+test('windows line endings', async t => {
+	const contents_windows_eol = contents_unix_eol.replace(/\n/g, '\r\n')
+
+	const { code, failed, output } = await verify(contents_windows_eol)
+	t.notOk(failed)
+})


### PR DESCRIPTION
Windows line endings weren't working, and I was getting weird error messages.

I also missed a couple tests in #17, so I fixed them in the first commit.