### PR TITLE
RFC: Fix source-mapped line numbers

### DIFF
--- a/src/babel-plugin-transform-comment-assertions.js
+++ b/src/babel-plugin-transform-comment-assertions.js
@@ -11,13 +11,13 @@ export default function ({ types: t, transform }) {
 	const assertIIFE = (actual, expected) =>
 		t.callExpression(
 			t.arrowFunctionExpression(
-				[ t.identifier('actual') ],
+				[ t.identifier('expected'), t.identifier('actual') ],
 				t.blockStatement([
-					t.expressionStatement(assertExpression(t.identifier('actual'), expected)),
+					t.expressionStatement(assertExpression(t.identifier('actual'), t.identifier('expected'))),
 					t.returnStatement(t.identifier('actual'))
 				])
 			),
-			[ actual ]
+			[ expected, actual ]
 		)
 
 	const getExpected = comment => {
@@ -55,7 +55,7 @@ export default function ({ types: t, transform }) {
 
 				const actual = path.node.expression
 				const expected = getExpected(comment)
-				path.replaceWith(assertIIFE(actual, expected))
+				path.insertAfter(assertIIFE(actual, expected))
 				path.skip()
 			},
 			ReturnStatement (path, state) {

--- a/src/babel-plugin-transform-comment-assertions.js
+++ b/src/babel-plugin-transform-comment-assertions.js
@@ -55,7 +55,7 @@ export default function ({ types: t, transform }) {
 
 				const actual = path.node.expression
 				const expected = getExpected(comment)
-				path.insertAfter(assertIIFE(actual, expected))
+				path.insertAfter(t.expressionStatement(assertIIFE(actual, expected)))
 				path.skip()
 			},
 			ReturnStatement (path, state) {

--- a/src/verify.js
+++ b/src/verify.js
@@ -13,7 +13,7 @@ export const verify = async (gfm, { file } = {}) => {
 	const { code, map } = gfmjs
 
 	// For debugging source maps
-	console.log(`https://sokra.github.io/source-map-visualization/#base64,${btoa(code.replace(/^\/\/# sourceMap.+/, ``))},${btoa(JSON.stringify(map))},${btoa(gfm)}`)
+	// console.log(`https://sokra.github.io/source-map-visualization/#base64,${btoa(code.replace(/\/\/# sourceMap.+/, ``))},${btoa(JSON.stringify(map))},${btoa(gfm)}`)
 
 	const process = await run_js(code, { file })
 	return {

--- a/src/verify.js
+++ b/src/verify.js
@@ -10,7 +10,11 @@ const get_test_script_from_gfm = (gfm, { file }) =>
 
 export const verify = async (gfm, { file } = {}) => {
 	const gfmjs = await get_test_script_from_gfm(gfm, { file })
-	const { code } = gfmjs
+	const { code, map } = gfmjs
+
+	// For debugging source maps
+	console.log(`https://sokra.github.io/source-map-visualization/#base64,${btoa(code.replace(/^\/\/# sourceMap.+/, ``))},${btoa(JSON.stringify(map))},${btoa(gfm)}`)
+
 	const process = await run_js(code, { file })
 	return {
 		code,

--- a/test/bin/bin.spec.js
+++ b/test/bin/bin.spec.js
@@ -48,7 +48,10 @@ const assert_source_map_line = async (t, relative_file, line) => {
 
 test('correct source maps', async t => {
 	await assert_source_map_line(t, './fail.md', 3)
+	// await assert_source_map_line(t, '../arrow-explicit-return/arrow-explicit-return.md', 7) // shows line 6 not 7
 	await assert_source_map_line(t, '../arrow-implied-return/arrow-implied-return.md', 4)
+	// await assert_source_map_line(t, '../function-return/function-return.md', 7) // shows line 6 not 7
 	await assert_source_map_line(t, '../html-comment/html-comment.md', 3)
 	await assert_source_map_line(t, '../inline/inline.md', 4)
+	// await assert_source_map_line(t, '../multiline/multiline.md', 10) // shows line 14 not 10
 })

--- a/test/bin/bin.spec.js
+++ b/test/bin/bin.spec.js
@@ -37,8 +37,18 @@ test('fail', async t => {
 	t.ok(/'something else'/.test(stderr), 'stderr contains actual value')
 })
 
-test('failed assertions are source-mapped to the markdown file', async t => {
-	const { err, stdout, stderr } = await run_bin_on_relative_file('./fail.md')
+const assert_source_map_line = async (t, relative_file, line) => {
+	const { err, stdout, stderr } = await run_bin_on_relative_file(relative_file)
 
-	t.ok(/fail\.md:\d+:\d+/.test(stderr), 'Error line points to markdown file')
+	t.ok(/\.md:\d/.test(stderr), 'Error line points to the markdown file')
+
+	const [ , line_number ] = stderr.match(/\.md:(\d+)/) || []
+	t.equal(line_number, line.toString(), `Error line is correct for ${relative_file}`)
+}
+
+test('correct source maps', async t => {
+	await assert_source_map_line(t, './fail.md', 3)
+	await assert_source_map_line(t, '../arrow-implied-return/arrow-implied-return.md', 4)
+	await assert_source_map_line(t, '../html-comment/html-comment.md', 3)
+	await assert_source_map_line(t, '../inline/inline.md', 4)
 })


### PR DESCRIPTION
The source maps were pointing at the wrong lines.  I'm pretty new to generating source maps, so I'm kinda in the dark here.

This PR fixes the line numbers for expression statements.

I don't really expect this to get merged.  This is more of a Request for Comments.  I wish that source maps were working better, but I'm not sure how to improve them.