### PR TITLE
Use parseSync instead of transform for Babel 8 compatibility and simplicity

### DIFF
--- a/src/babel-plugin-add-imports.js
+++ b/src/babel-plugin-add-imports.js
@@ -1,4 +1,4 @@
-export default names => ({ types: t, transform }) => {
+export default names => ({ types: t }) => {
 	return {
 		visitor: {
 			Program (path, { file, opts }) {

--- a/src/babel-plugin-transform-comment-assertions.js
+++ b/src/babel-plugin-transform-comment-assertions.js
@@ -1,7 +1,7 @@
 const commentAssertionRegex = /^\s*=>\s*/
 const isCommentAssertion = comment => comment ? commentAssertionRegex.test(comment.value) : false
 
-export default function ({ types: t, transformSync }) {
+export default function ({ types: t, parseSync }) {
 	const assertExpression = (actual, expected) =>
 		t.callExpression(
 			t.memberExpression(t.identifier('assert'), t.identifier('deepEqual')),
@@ -22,8 +22,8 @@ export default function ({ types: t, transformSync }) {
 
 	const getExpected = comment => {
 		const expectedText = comment.value.replace(commentAssertionRegex, '').trim()
-		return transformSync(`() => (${expectedText})`, { ast: true })
-			.ast.program.body[0].expression.body
+		return parseSync(`() => (${expectedText})`)
+			.program.body[0].expression.body
 	}
 
 	return {

--- a/src/babel-plugin-transform-comment-assertions.js
+++ b/src/babel-plugin-transform-comment-assertions.js
@@ -1,7 +1,7 @@
 const commentAssertionRegex = /^\s*=>\s*/
 const isCommentAssertion = comment => comment ? commentAssertionRegex.test(comment.value) : false
 
-export default function ({ types: t, transform }) {
+export default function ({ types: t, transformSync }) {
 	const assertExpression = (actual, expected) =>
 		t.callExpression(
 			t.memberExpression(t.identifier('assert'), t.identifier('deepEqual')),
@@ -22,7 +22,7 @@ export default function ({ types: t, transform }) {
 
 	const getExpected = comment => {
 		const expectedText = comment.value.replace(commentAssertionRegex, '').trim()
-		return transform(`() => (${expectedText})`, { ast: true })
+		return transformSync(`() => (${expectedText})`, { ast: true })
 			.ast.program.body[0].expression.body
 	}
 


### PR DESCRIPTION
Two minor changes:

1. Specifying the "synchronous" version of a function.  Babel used to have just `transform` which is synchronous, but now they have `transform`, `transformSync`, and `transformAsync`.  `transform` is deprecated, and will be removed in Babel 8.
2. Switching from `transformSync` to `parseSync`.  `transformSync` returns code, source maps, and an AST.  `parseSync` just returns the AST, so I'm assuming `parseSync` is more efficient than `transformSync`.